### PR TITLE
ci: caching & least permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [master]
 
 permissions: {}
 
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust:latest
-    steps:
+      env:
+        CARGO_HOME: "/cargo/"
 
+    steps:
       - name: ensure node is installed for act
         if: ${{ env.ACT }}
         run: command -v node || (apt update && apt install -y nodejs zstd)
@@ -23,11 +25,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache cargo dir
+        id: cargo-dir
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
+          path: /cargo
+
       - name: Cache target dir
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-target-dir
+          key: ${{ runner.os }}-target-dir-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-target-dir
           path: target
 
       - name: dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
         run: command -v node || (apt update && apt install -y nodejs zstd)
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cache target dir
         id: target-dir

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [master]
 
 permissions: {}
 
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust:latest
-    steps:
+      env:
+        CARGO_HOME: "/cargo/"
 
+    steps:
       - name: ensure node is installed for act
         if: ${{ env.ACT }}
         run: command -v node || (apt update && apt install -y nodejs zstd)
@@ -23,11 +25,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache cargo dir
+        id: cargo-dir
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
+          path: /cargo
+
       - name: Cache target dir
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-target-dir
+          key: ${{ runner.os }}-target-dir-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-target-dir
           path: target
 
       - name: rustup add components

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,8 @@ jobs:
         run: command -v node || (apt update && apt install -y nodejs zstd)
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cache target dir
         id: target-dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "v*.*.*"
 
+permissions: {}
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
   check_version:
     needs: [build, test, lint]
     runs-on: ubuntu-latest
+    env:
+      REF_NAME: ${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Check crate version
-        run: "[[ \"v$(yq '.package.version' Cargo.toml)\" == \"${{ github.ref_name }}\" ]]"
+        run: '[[ "v$(yq ''.package.version'' Cargo.toml)" == "$REF_NAME" ]]'
 
   # Create a github release
   github_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check crate version
         run: "[[ \"v$(yq '.package.version' Cargo.toml)\" == \"${{ github.ref_name }}\" ]]"
@@ -36,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -60,6 +64,8 @@ jobs:
         run: command -v node || (apt update && apt install -y --no-install-recommends nodejs)
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Publish crate
         if: ${{ env.CARGO_REGISTRY_TOKEN != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         with:
           generate_release_notes: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,10 @@ jobs:
   # Create a github release
   github_release:
     needs: [build, test, lint, check_version]
-
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -49,8 +51,6 @@ jobs:
   # Publish the crate (scoping the secret to only this job)
   publish_crate:
     needs: [build, test, lint, github_release]
-    permissions:
-      contents: write
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         run: command -v node || (apt install -y --no-install-recommends nodejs zstd)
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cache target dir
         id: target-dir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [master]
 
 permissions: {}
 
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust:latest
-    steps:
+      env:
+        CARGO_HOME: "/cargo/"
 
+    steps:
       - name: install dependencies
         run: apt update && apt install -y --no-install-recommends gpg pass
 
@@ -26,11 +28,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache cargo dir
+        id: cargo-dir
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
+          path: /cargo
+
       - name: Cache target dir
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-target-dir
+          key: ${{ runner.os }}-target-dir-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-target-dir
           path: target
 
       - name: cargo test


### PR DESCRIPTION
🧹 

---

* ci: restricted workflow permissions (e4540c7)
      
      Remove unused permissions from workflow run.

* ci: remove github token from git config (9a8ca65)
      
      Use "persist-credentials: false" to disable embedding credentials in the
      git config.

* ci: increased caching (63b64a2)
      
      Cache cargo state between runs.

* ci: pin action-gh-release to commit (5c46f01)
      
      Instead of a mutable tag to prevent compromise of the action from
      affecting this repo.

* ci: increased perms needed for release publish (6005d0f)
      
      The publish step needs increased perms - not publishing cargo crates.

* ci: isolate github.ref_name from shell exec (ab63a23)
      
      This could be used for shell injection (though it is impractical in this
      repo).

