### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-pass"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "assert_cmd",
  "cargo-credential",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-credential-pass"
 description = "Keep your cargo registry tokens encrypted in your pass store"
 authors = ["Dom Dwyer <dom@itsallbroken.com>"]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 
 license = "Apache-2.0"


### PR DESCRIPTION
Release updated `cargo-credential` dep.

---

* chore: bump version to 1.1.1 (8c5662c)
      

